### PR TITLE
Under approval_custom module, fix manifest error syntax

### DIFF
--- a/addons/approval_custom/__manifest__.py
+++ b/addons/approval_custom/__manifest__.py
@@ -3,6 +3,5 @@
 {
     'name': 'Approvals',
     'version': '0.1',
-    'summary': 'Create and validate approval requests
-    '
+    'summary': 'Create and validate approval requests'
 }


### PR DESCRIPTION
Error syntax manifest at approval_custom

![image](https://user-images.githubusercontent.com/27566114/196396385-22377cca-05ec-452d-ba6f-92a4327c71ef.png)
